### PR TITLE
Travis CI: Drop legacy Python, Add more flake8 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,11 @@
 group: travis_latest
 language: python
+python: 3.7
 cache: pip
-matrix:
-  include:
-    - python: 2.7
-    #- python: 3.4
-    #- python: 3.5
-    - python: 3.6
-    #- python: 3.7
-    #  dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
-    #  sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
-install:
-  - pip install -r setup/requirements.txt
-  - pip install flake8
+install: pip install flake8 -r setup/requirements.txt
 before_script:
   # stop the build if there are Python syntax errors or undefined names
-  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 group: travis_latest
+dist: xenial
 language: python
 python: 3.7
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: xenial
 language: python
 python: 3.7
 cache: pip
-install: pip install flake8 -r setup/requirements.txt
+install: pip install flake8  # -r setup/requirements.txt
 before_script:
   # stop the build if there are Python syntax errors or undefined names
   - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/modules/twitterfinder.py
+++ b/modules/twitterfinder.py
@@ -3,6 +3,7 @@ from selenium import webdriver
 from selenium.webdriver.common.keys import Keys
 from pyvirtualdisplay import Display
 from time import sleep
+import traceback
 import sys
 import os
 from bs4 import BeautifulSoup


### PR DESCRIPTION
$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./modules/twitterfinder.py:59:5: F821 undefined name 'traceback'
				traceback.print_exc()
    ^
1     F821 undefined name 'traceback'
1
```
https://travis-ci.org/Greenwolf/social_mapper/pull_requests